### PR TITLE
fix for tabbing issues

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -723,7 +723,7 @@ class Chat {
                 users.push(this.addUser(data));
             if(data.hasOwnProperty('users'))
                 users = users.concat(Array.from(data.users).map(d => this.addUser(d)));
-            users.forEach(u => this.autocomplete.add(u.nick, false, now));
+            users.forEach(u => this.autocomplete.add(u.nick, false));
         }
     }
 

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -718,7 +718,6 @@ class Chat {
     onDISPATCH({data}){
         if (typeof data === 'object'){
             let users = [];
-            const now = Date.now();
             if(data.hasOwnProperty('nick'))
                 users.push(this.addUser(data));
             if(data.hasOwnProperty('users'))


### PR DESCRIPTION
When increasing the tab preference for an user would get Date.now() as the number. Giving users Date.now() as default on join would push them in front of the autocomplete list when they joined.

