### PR TITLE
Quick fix for user-name tab completion bug

### DIFF
--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -238,12 +238,11 @@ class ChatAutoComplete {
         updateHelpers(this);
     }
 
-    add(str, isemote = false, weight = 1) {
+    add(str, isemote = false) {
         const id = getBucketId(str);
         const bucket = this.buckets.get(id) || this.buckets.set(id, new Map()).get(id);
         const data = Object.assign(bucket.get(str) || {}, {
             data: str,
-            weight: weight,
             isemote: isemote
         });
         bucket.set(str, data);

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -241,13 +241,14 @@ class ChatAutoComplete {
     add(str, isemote = false) {
         const id = getBucketId(str);
         const bucket = this.buckets.get(id) || this.buckets.set(id, new Map()).get(id);
-        const candidate = bucket.get(str);
+        let candidate = bucket.get(str);
         if (!candidate) {
-            bucket.set(str, {
+            candidate = {
                 data: str,
                 weight: 0,
                 isemote: isemote
-            });
+            };
+            bucket.set(str, candidate);
         }
         return candidate;
     }

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -242,13 +242,14 @@ class ChatAutoComplete {
         const id = getBucketId(str);
         const bucket = this.buckets.get(id) || this.buckets.set(id, new Map()).get(id);
         const candidate = bucket.get(str);
-        const data = Object.assign(candidate || {}, {
-            data: str,
-            weight: candidate ? candidate.weight || 0 : 0,
-            isemote: isemote
-        });
-        bucket.set(str, data);
-        return data;
+        if (!candidate) {
+            bucket.set(str, {
+                data: str,
+                weight: 0,
+                isemote: isemote
+            });
+        }
+        return candidate;
     }
 
     remove(str) {

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -241,8 +241,10 @@ class ChatAutoComplete {
     add(str, isemote = false) {
         const id = getBucketId(str);
         const bucket = this.buckets.get(id) || this.buckets.set(id, new Map()).get(id);
-        const data = Object.assign(bucket.get(str) || {}, {
+        const candidate = bucket.get(str);
+        const data = Object.assign(candidate || {}, {
             data: str,
+            weight: candidate ? candidate.weight || 0 : 0,
             isemote: isemote
         });
         bucket.set(str, data);


### PR DESCRIPTION
Remove unused parameter weight in ChatAutoComplete.add(), checked all usages with Visual Code and it seemed completely unused so removing it might not even break anything like I thought it would Abathur