### PR TITLE
 Move autocomplete promotion logic to cmdSEND()

### DIFF
--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -250,7 +250,7 @@ class ChatAutoComplete {
         return candidate;
     }
 
-    promoteLastSeen(str) {
+    promoteOneLastSeen(str) {
         const id = getBucketId(str);
         const bucket = this.buckets.get(id) || this.buckets.set(id, new Map()).get(id);
         let candidate = bucket.get(str);
@@ -260,8 +260,7 @@ class ChatAutoComplete {
         return candidate;
     }
 
-    parseAndPromoteLastUsed(msg) {
-        let words = msg.split(' ');
+    promoteManyLastUsed(words) {
         for (let i = 0, l = words.length; i < l; i++) {
             let word = words[i];
             const bucket = this.buckets.get(getBucketId(word));

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -271,6 +271,7 @@ class ChatAutoComplete {
             candidate.lastUsed = Date.now();
             bucket.set(word, candidate);
         }
+        return words;
     }
 
     remove(str) {

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -11,11 +11,6 @@ function getBucketId(id) {
     return (id.match(/[\S]/)[0] || '_').toLowerCase();
 }
 
-function promoteIfSelected(ac) {
-    if (ac.selected >= 0 && ac.results[ac.selected]) {
-        ac.results[ac.selected].lastUsed = Date.now();
-    }
-}
 function sortResults(a, b) {
     if (!a || !b) { return 0; }
 
@@ -151,10 +146,8 @@ class ChatAutoComplete {
 
             const char = String.fromCharCode(keycode) || '';
             if (keycode === KEYCODES.ENTER) {
-                promoteIfSelected(this);
                 this.reset();
             } else if (char.length > 0) {
-                promoteIfSelected(this);
                 const str = this.input.val().toString();
 
                 const offset = this.input[0].selectionStart + 1;
@@ -257,7 +250,7 @@ class ChatAutoComplete {
         return candidate;
     }
 
-    update(str) {
+    promoteLastSeen(str) {
         const id = getBucketId(str);
         const bucket = this.buckets.get(id) || this.buckets.set(id, new Map()).get(id);
         let candidate = bucket.get(str);
@@ -265,6 +258,19 @@ class ChatAutoComplete {
         candidate.lastSeen = Date.now();
         bucket.set(str, candidate);
         return candidate;
+    }
+
+    parseAndPromoteLastUsed(msg) {
+        let words = msg.split(' ');
+        for (let i = 0, l = words.length; i < l; i++) {
+            let word = words[i];
+            const bucket = this.buckets.get(getBucketId(word));
+            if (!bucket) continue;
+            let candidate = bucket.get(word);
+            if (!candidate) continue;
+            candidate.lastUsed = Date.now();
+            bucket.set(word, candidate);
+        }
     }
 
     remove(str) {

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -912,10 +912,10 @@ class Chat {
             const win = this.getActiveWindow(),
                  isme = str.substring(0, 4).toLowerCase() === '/me ',
             iscommand = !isme && str.substring(0, 1) === '/' && str.substring(0, 2) !== '//'
-            this.autocomplete.parseAndPromoteLastUsed(str);
+            let splittedStr = this.autocomplete.parseAndPromoteLastUsed(str);
             // COMMAND
             if (iscommand) {
-                const command = iscommand ? str.split(' ', 1)[0] : '',
+                const command = iscommand ? splittedStr[0] : '',
                    normalized = command.substring(1).toUpperCase()
                 if(win !== this.mainwindow && normalized !== 'EXIT'){
                     MessageBuilder.error(`No commands in private windows. Try /exit`).into(this, win)

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -773,7 +773,7 @@ class Chat {
                 MessageBuilder.emote(textonly, data.timestamp, 2).into(this)
             }
         } else if(!this.resolveMessage(data.nick, data.data)){
-            this.autocomplete.promoteLastSeen(data.nick);
+            this.autocomplete.promoteOneLastSeen(data.nick);
             const user = this.users.get(data.nick.toLowerCase());
             MessageBuilder.message(data.data, user, data.timestamp).into(this)
             if (user.hasAnyFeatures('admin', 'moderator')) {
@@ -912,7 +912,8 @@ class Chat {
             const win = this.getActiveWindow(),
                  isme = str.substring(0, 4).toLowerCase() === '/me ',
             iscommand = !isme && str.substring(0, 1) === '/' && str.substring(0, 2) !== '//'
-            let splittedStr = this.autocomplete.parseAndPromoteLastUsed(str);
+            let splittedStr = str.split(' ');
+            this.autocomplete.promoteManyLastUsed(splittedStr);
             // COMMAND
             if (iscommand) {
                 const command = iscommand ? splittedStr[0] : '',

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -773,7 +773,7 @@ class Chat {
                 MessageBuilder.emote(textonly, data.timestamp, 2).into(this)
             }
         } else if(!this.resolveMessage(data.nick, data.data)){
-            this.autocomplete.update(data.nick);
+            this.autocomplete.promoteLastSeen(data.nick);
             const user = this.users.get(data.nick.toLowerCase());
             MessageBuilder.message(data.data, user, data.timestamp).into(this)
             if (user.hasAnyFeatures('admin', 'moderator')) {
@@ -912,6 +912,7 @@ class Chat {
             const win = this.getActiveWindow(),
                  isme = str.substring(0, 4).toLowerCase() === '/me ',
             iscommand = !isme && str.substring(0, 1) === '/' && str.substring(0, 2) !== '//'
+            this.autocomplete.parseAndPromoteLastUsed(str);
             // COMMAND
             if (iscommand) {
                 const command = iscommand ? str.split(' ', 1)[0] : '',


### PR DESCRIPTION
Implementation of: https://github.com/MemeLabs/chat-gui/issues/53

The idea is to separate autocomplete promotion logic from autocomplete selection logic.
You can now type out someone's name and they will be promoted for the autocomplete if you choose to do it next. This also lets you correct a 'mis-tab' by deleting and typing and still benefit from autocomplete promotion.

I also took the chance to rename all that stuff, to make it clear which weight which function changes (lastSeen or lastUsed), as well as calling it 'promotion' like the original function did, rather than 'update', seems more explicit to me.