### PR TITLE
Fix promoting autocomplete candidates while typing a message

### DIFF
--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -11,6 +11,12 @@ function getBucketId(id) {
     return (id.match(/[\S]/)[0] || '_').toLowerCase();
 }
 
+function promoteIfSelected(ac) {
+    if (ac.selected >= 0 && ac.results[ac.selected]) {
+        ac.results[ac.selected].lastUsed = Date.now();
+    }
+}
+
 function sortResults(a, b) {
     if (!a || !b) { return 0; }
 
@@ -146,8 +152,10 @@ class ChatAutoComplete {
 
             const char = String.fromCharCode(keycode) || '';
             if (keycode === KEYCODES.ENTER) {
+                promoteIfSelected(this);
                 this.reset();
             } else if (char.length > 0) {
+                promoteIfSelected(this);
                 const str = this.input.val().toString();
 
                 const offset = this.input[0].selectionStart + 1;


### PR DESCRIPTION
Sorry, I even thought about it when planning out the changes, but then forgot when i was actually typing the code - I nuked the parts of the code which promoted tokens while typing a message.

This PR is just to bring that functionality back, by throwing promoteIfSelected() back into autocomplete.js, and calling it where it used to be called in autocomplete.search() as it was before my changes.