### PR TITLE
Post valentines update fixes

### DIFF
--- a/assets/chat/css/generify.scss
+++ b/assets/chat/css/generify.scss
@@ -150,10 +150,13 @@
 
     @at-root {
         @keyframes generify-love__heart--animation {
+            0%, 2% {
+                opacity: 0;
+            }
             0% {
                 visibility: visible;
                 transform: scale(0);
-                bottom: -5px;
+                bottom: -30%;
             }
 
             50% {
@@ -163,7 +166,7 @@
 
             100% {
                 transform: scale(0.6);
-                bottom: 20px;
+                bottom: 50%;
                 opacity: 0;
             }
         }
@@ -188,15 +191,12 @@
     }
 
     &::after {
-        /* right-outer heart */
+        /* right-inner heart */
         @include heart;
-        right: -8px;
-        animation-delay: -($animation-duration - $animation-duration*0.50);
+        right: -2px;
     }
 
     & .chat-emote {
-        overflow: visible;
-
         &::before {
             /* left-inner heart */
             @include heart;
@@ -205,9 +205,10 @@
         }
 
         &::after {
-            /* right-inner heart */
+            /* right-outer heart */
             @include heart;
-            right: -3px;
+            right: -7px;
+            animation-delay: -($animation-duration - $animation-duration*0.50);
         }
     }
 

--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -202,7 +202,6 @@ label small {
      * to the same size.
      */
     width: 100%;
-    word-break: break-all;
     box-sizing: border-box;
     padding: 5px;
     border: 1px solid #321a10;
@@ -312,9 +311,6 @@ label small {
         border-style: solid;
         border-color: transparent;
         border-width: 1px 0 1px 0;
-
-        // padding to improve clickability
-        padding: 3px 0;
     }
     .externallink {
         color: $color-link;

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -321,9 +321,21 @@ class Chat {
          * contain the text entered.
          */
         const inputScaler = this.ui.find('#chat-input-scaler');
+        let lastHeightScaler = 0;
 
         this.input.on('input keydown', () => {
+            // Get pinned state before syncing the scaler
+            const wasScrollPinned = this.mainwindow.scrollplugin.isPinned();
             inputScaler.text(this.input.val());
+
+            if (lastHeightScaler !== inputScaler.height()) {
+                lastHeightScaler = inputScaler.height();
+                this.mainwindow.scrollplugin.reset();
+
+                if (wasScrollPinned) {
+                    this.mainwindow.updateAndPin();
+                }
+            }
         });
 
         // Chat focus / menu close when clicking on some areas


### PR DESCRIPTION
- Keep scroll position locked when chat-input scales

- Revert link padding/nsfw underline offset.
    Will take another look at it together with issue #60
- Fix word-breaking on chat-input.
- Fix emote offset on emote combos with :love modifier.
- Prevent :love modifier blinking under stress on Firefox.