### PR TITLE
add generify-flip and clean up css

### DIFF
--- a/assets/chat/css/generify.scss
+++ b/assets/chat/css/generify.scss
@@ -7,11 +7,7 @@
 .anim-fix {
     padding-top: 14px;
     margin-top: -10px;
-    margin-bottom: -12px;
-}
-
-.anim-fix > .chat-emote {
-    margin-bottom: 10px;
+    margin-bottom: -7px;
 }
 
 .generify-rustle > .chat-emote {
@@ -23,18 +19,11 @@
 }
 
 .mirror {
-    -moz-transform: scaleX(-1);
-    -o-transform: scaleX(-1);
-    -webkit-transform: scaleX(-1);
     transform: scaleX(-1);
+}
 
-    //fix "blur" or mirrored emotes
-    image-rendering: optimizeSpeed;
-    image-rendering: -moz-crisp-edges;
-    image-rendering: -o-crisp-edges;
-    image-rendering: -webkit-optimize-contrast;
-    image-rendering: optimize-contrast;
-    -ms-interpolation-mode: nearest-neighbor;
+.flip {
+    transform: scaleY(-1);
 }
 
 .generify-dank {

--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -529,11 +529,6 @@ a.flair12:hover {
     }
 }
 
-/* Emote combo / message */
-.msg-emote .chat-emote {
-    vertical-align: baseline;
-}
-
 /* Censored */
 .censored .text {
     display: none;

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -51,7 +51,7 @@ function isKeyCode(e, code) {
 // emote:key; css class to apply
 const GENERIFY_OPTIONS = {
     'mirror': 'mirror',
-    'flip':'flip',
+    'flip': 'flip',
     'rain': 'weather rain anim-fix',
     'snow': 'weather snow anim-fix',
     'rustle': 'generify-rustle',

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -51,6 +51,7 @@ function isKeyCode(e, code) {
 // emote:key; css class to apply
 const GENERIFY_OPTIONS = {
     'mirror': 'mirror',
+    'flip':'flip',
     'rain': 'weather rain anim-fix',
     'snow': 'weather snow anim-fix',
     'rustle': 'generify-rustle',


### PR DESCRIPTION
- Closes https://github.com/MemeLabs/chat-gui/issues/77
- Closes https://github.com/MemeLabs/chat-gui/issues/36

Let's hope the removed css rules aren't needed anywhere anymore. Tested with
- Mozilla Firefox 66.0.2
- Chromium 73.0.3683.86
- Thanks to @talleyp for safari testing!