### PR TITLE
fix emote bug, enable greentext code blocks

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -278,6 +278,7 @@ label small {
 .msg-chat code {
     background-color: rgb(51, 51, 51);
     border-radius: 3px;
+    color: $color-chat-text2;
     white-space: pre-wrap;
 }
 

--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -134,7 +134,7 @@ class EmoteFormatter {
                 ...chat.emoticons,
             ].join('|');
             const suffixes = Object.keys(GENERIFY_OPTIONS).join('|');
-            this.regex = new RegExp(`(^|\\s)(${emoticons})(:(${suffixes}))?(?=$|\\s)(?=(?:[^<code>]*<code>[^</code>]*</code>)*[^<code>]*$)`, 'gm');
+            this.regex = new RegExp(`(^|\\s)(${emoticons})(:(${suffixes}))?(?=$|\\s)(?=(?:[^ ]* [^ ]* )*[^ ]*$)`, 'gm');
         }
 
         if (!this.emotewidths) {
@@ -222,7 +222,7 @@ function stringCodeParser(str) {
         var indexTwo = findNextTick(afterTick);
         if (indexTwo !== -1) {
             var betweenTicks = afterTick.substring(0, indexTwo).replace(/\r?\n|\r/g, '');
-            str = (str.substring(0, indexOne) + `<code>${betweenTicks}</code>` + stringCodeParser(afterTick.substring(indexTwo + 1)));
+            str = (str.substring(0, indexOne) + `<code> ${betweenTicks} </code>` + stringCodeParser(afterTick.substring(indexTwo + 1)));
         }
     }
     return str;
@@ -230,10 +230,7 @@ function stringCodeParser(str) {
 
 class CodeFormatter {
     format(chat, str, message = null) {
-        if (str.indexOf('&gt;') !== 0) {
-            str = stringCodeParser(str);
-        }
-        return str.replace(/\\`/g, '`');
+        return stringCodeParser(str).replace(/\\`/g, '`');
     }
 }
 


### PR DESCRIPTION
The linter complains about irregular whitespace, but we need that to detect code blocks (see https://github.com/MemeLabs/chat-gui/issues/97#issuecomment-491976468)

This also adresses both requests of https://github.com/MemeLabs/chat-gui/issues/96