### PR TITLE
change how code formatting works

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -276,6 +276,9 @@ label small {
 
 /* Code Tag */
 .msg-chat code {
+    font-style: normal;
+    padding-right: 3px;
+    padding-left: 3px;
     background-color: rgb(51, 51, 51);
     border-radius: 3px;
     color: $color-chat-text2;

--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -217,7 +217,7 @@ function findNextTick(str) {
 
 // surrounds code with code tags,
 // replaces empty string and string only containing whitespace with single space
-function stringCodeParser(str) {
+function stringCodeFormatter(str) {
     if (RegExp('^\\s*$').test(str)) {
         str = ' ';
     }
@@ -231,28 +231,24 @@ function stringCodeSplitter(str) {
         var beforeFirstTick = str.substring(0, indexOne);
         var afterFirstTick = str.substring(indexOne + 1);
         var indexTwo = findNextTick(afterFirstTick);
-        if (indexTwo !== -1) {
+        if (indexTwo !== -1 && indexTwo + indexOne > indexOne) {
             var betweenTicks = afterFirstTick.substring(0, indexTwo).replace(/\r?\n|\r/g, '');
             var afterSecondTick = afterFirstTick.substring(indexTwo + 1);
-            var subArray;
-            if (beforeFirstTick.length > 0) {
-                subArray = [[beforeFirstTick, '0'], [betweenTicks, '1']];
-            } else {
-                subArray = [[betweenTicks, '1']];
-            }
+            var subArray = (beforeFirstTick.length > 0)
+                ? subArray = [{ type: 'text', value: beforeFirstTick }, { type: 'code', value: betweenTicks }]
+                : subArray = [{ type: 'code', value: betweenTicks }];
             if (afterSecondTick.length > 0) {
                 return subArray.concat(stringCodeSplitter(afterSecondTick));
-            } else {
-                return subArray;
             }
+            return subArray;
         }
     }
-    return [[str, '0']];
+    return [{ type: 'text', value: str }];
 }
 
 class CodeFormatter {
     format(chat, str, message = null) {
-        return stringCodeParser(str);
+        return stringCodeFormatter(str);
     }
 
     split(str) {

--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -231,12 +231,17 @@ function stringCodeSplitter(str) {
         var beforeFirstTick = str.substring(0, indexOne);
         var afterFirstTick = str.substring(indexOne + 1);
         var indexTwo = findNextTick(afterFirstTick);
-        if (indexTwo !== -1 && indexTwo + indexOne > indexOne) {
+        if (indexTwo !== -1) {
             var betweenTicks = afterFirstTick.substring(0, indexTwo).replace(/\r?\n|\r/g, '');
+            var subArray;
+            if (indexTwo + indexOne === indexOne) {
+                subArray = [{ type: 'text', value: str.substring(0, indexOne + indexTwo + 2) }];
+            } else {
+                subArray = (beforeFirstTick.length > 0)
+                    ? subArray = [{ type: 'text', value: beforeFirstTick }, { type: 'code', value: betweenTicks }]
+                    : subArray = [{ type: 'code', value: betweenTicks }];
+            }
             var afterSecondTick = afterFirstTick.substring(indexTwo + 1);
-            var subArray = (beforeFirstTick.length > 0)
-                ? subArray = [{ type: 'text', value: beforeFirstTick }, { type: 'code', value: betweenTicks }]
-                : subArray = [{ type: 'code', value: betweenTicks }];
             if (afterSecondTick.length > 0) {
                 return subArray.concat(stringCodeSplitter(afterSecondTick));
             }

--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -205,11 +205,12 @@ function findNextTick(str) {
         var index = str.indexOf('`');
         if (index === -1) {
             return -1;
-        } else if (str.charAt(index - 1) !== '\\') {
-            return index + base;
+        } else if (str.charAt(index + 1) === '`' || str.charAt(index - 1) === '\\') {
+            var step = (str.charAt(index + 1) === '`') ? index + 2 : index + 1;
+            base += step;
+            str = str.substring(step);
         } else {
-            base += index + 1;
-            str = str.substring(index + 1);
+            return index + base;
         }
     }
     return -1;
@@ -233,15 +234,10 @@ function stringCodeSplitter(str) {
         var indexTwo = findNextTick(afterFirstTick);
         if (indexTwo !== -1) {
             var betweenTicks = afterFirstTick.substring(0, indexTwo).replace(/\r?\n|\r/g, '');
-            var subArray;
-            if (indexTwo + indexOne === indexOne) {
-                subArray = [{ type: 'text', value: str.substring(0, indexOne + indexTwo + 2) }];
-            } else {
-                subArray = (beforeFirstTick.length > 0)
-                    ? subArray = [{ type: 'text', value: beforeFirstTick }, { type: 'code', value: betweenTicks }]
-                    : subArray = [{ type: 'code', value: betweenTicks }];
-            }
             var afterSecondTick = afterFirstTick.substring(indexTwo + 1);
+            var subArray = (beforeFirstTick.length > 0)
+                ? subArray = [{ type: 'text', value: beforeFirstTick }, { type: 'code', value: betweenTicks }]
+                : subArray = [{ type: 'code', value: betweenTicks }];
             if (afterSecondTick.length > 0) {
                 return subArray.concat(stringCodeSplitter(afterSecondTick));
             }

--- a/assets/chat/js/messages.js
+++ b/assets/chat/js/messages.js
@@ -39,14 +39,14 @@ function buildMessageTxt(chat, message) {
     var msgArray = codeFmt.split(msg);
     var fullMsg = '';
     for (var i = 0; i < msgArray.length; i++) {
-        if (msgArray[i][1] === '0') {
+        if (msgArray[i].type === 'text') {
             // format non code segment
-            formatters.forEach(f => msgArray[i][0] = f.format(chat, msgArray[i][0], message));
-        } else {
+            formatters.forEach(f => msgArray[i].value = f.format(chat, msgArray[i].value, message));
+        } else if (msgArray[i].type === 'code') {
             // format code segment
-            msgArray[i][0] = codeFmt.format(chat, msgArray[i][0], message);
+            msgArray[i].value = codeFmt.format(chat, msgArray[i].value, message);
         }
-        fullMsg += msgArray[i][0];
+        fullMsg += msgArray[i].value;
     }
     fullMsg = fullMsg.replace(/\\`/g, '`');
     return `<span class="text">${fullMsg}</span>`;

--- a/assets/chat/js/messages.js
+++ b/assets/chat/js/messages.js
@@ -21,7 +21,6 @@ const formatters = new Map()
 formatters.set('html', new HtmlTextFormatter())
 formatters.set('url', new UrlFormatter())
 formatters.set('mentioned', new MentionedUserFormatter())
-formatters.set('code', new CodeFormatter())
 
 // init with formatters that do nothing, and fill with real ones depending on settings.
 // (other code depends on those formatters existsing...)
@@ -33,11 +32,24 @@ function setFormattersFromSettings(settings) {
     if (settings.get('formatter-green')) formatters.set('green', new GreenTextFormatter());
 }
 
-function buildMessageTxt(chat, message){
+function buildMessageTxt(chat, message) {
     // TODO we strip off the `/me ` of every message -- must be a better way to do this
-    let msg = message.message.substring(0, 4).toLowerCase() === '/me ' ? message.message.substring(4) : message.message
-    formatters.forEach(f => msg = f.format(chat, msg, message))
-    return `<span class="text">${msg}</span>`
+    let msg = message.message.substring(0, 4).toLowerCase() === '/me ' ? message.message.substring(4) : message.message;
+    var codeFmt = new CodeFormatter();
+    var msgArray = codeFmt.split(msg);
+    var fullMsg = '';
+    for (var i = 0; i < msgArray.length; i++) {
+        if (msgArray[i][1] === '0') {
+            // format non code segment
+            formatters.forEach(f => msgArray[i][0] = f.format(chat, msgArray[i][0], message));
+        } else {
+            // format code segment
+            msgArray[i][0] = codeFmt.format(chat, msgArray[i][0], message);
+        }
+        fullMsg += msgArray[i][0];
+    }
+    fullMsg = fullMsg.replace(/\\`/g, '`');
+    return `<span class="text">${fullMsg}</span>`;
 }
 function buildFeatures(user){
     const features = [...user.features || []]


### PR DESCRIPTION
This addresses everything in https://github.com/MemeLabs/chat-gui/issues/99 except the last point (Dashh told me to hold on that for now)

Code formatting now works like this:
Messages first get split into code and non code like this
```"normal text `code` normal text 2 `more code`"``` ->
```[["normal text ", "0"], ["code", "1"], [" normal text 2 ", "0"], ["more code", "1"]]```
then non code segments are run through all the formatters and code is only run though the code formatter.