### PR TITLE
fix error when message contains newline

### DIFF
--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -8,7 +8,10 @@ let minWordLength = 1;
 let maxResults = 20;
 
 function getBucketId(id) {
-    return (id.match(/[\S]/)[0] || '_').toLowerCase();
+    var match = id.match(/[\S]/);
+    if (match != null) {
+        return (match[0] || '_').toLowerCase();
+    }
 }
 
 function promoteIfSelected(ac) {


### PR DESCRIPTION
Fix being unable to send a message if it matches `[^\s]+ \n [^\s]+`

Paste this into chat and try to send to test it out
```
test 
 testing
```

An error already appears when the message matches `[^\s]+ \n`, but it doesn't appear to affect anything.