### PR TITLE
Fix for incorrect rendering of golden rare emotes on chrome and other chromium based browsers

### DIFF
--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -129,9 +129,9 @@ function genGoldenEmote(emoteName, emoteHeight, emoteWidth) {
     let imgSrc = innerEmoteCompStyle.backgroundImage;
     const maskUrl = imgSrc.match(imgSrcRegex)[0];
 
-    const goldenModifierMask = 'width: ' + emoteWidth + 'px; height: ' + emoteHeight + 'px; ' + 'mask-position: ' + innerEmoteCompStyle.backgroundPosition + ';';
+    const goldenModifierMask = 'width: ' + emoteWidth + 'px; height: ' + emoteHeight + 'px; ' + '-webkit-mask-position: ' + innerEmoteCompStyle.backgroundPosition + ';';
     const goldenModifierMarginTop = (30 - emoteHeight) - 8;
-    const goldenModifierStyle = 'style="margin:' + goldenModifierMarginTop + 'px 2px 0px 2px; mask: url(/'+ maskUrl + ');' + goldenModifierMask + '"';
+    const goldenModifierStyle = 'style="margin:' + goldenModifierMarginTop + 'px 2px 0px 2px; -webkit-mask-image: url(/'+ maskUrl + ');' + goldenModifierMask + '"';
     
     const goldenModifierGlimmerStyle = 'style="width: ' + emoteWidth + 'px; height: ' + emoteHeight + 'px;"';
     const goldenModifierGlimmer = '<span ' + goldenModifierGlimmerStyle + ' class="golden-glimmer"></span>';
@@ -222,7 +222,7 @@ class EmoteFormatter {
             
             var goldenModifier = "";
             var goldenModifierInnerEmoteStyle= "";
-            let goldenProcChance = 0.00001000;
+            let goldenProcChance = 1.00001000;
             if (emoteCount / 2 > 1) {
                 // more than 2 emotes will lower the chance of a rare
                 goldenProcChance = goldenProcChance / (emoteCount / 2);

--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -222,7 +222,7 @@ class EmoteFormatter {
             
             var goldenModifier = "";
             var goldenModifierInnerEmoteStyle= "";
-            let goldenProcChance = 1.00001000;
+            let goldenProcChance = 0.00001000;
             if (emoteCount / 2 > 1) {
                 // more than 2 emotes will lower the chance of a rare
                 goldenProcChance = goldenProcChance / (emoteCount / 2);


### PR DESCRIPTION
The effect should look like this https://i.imgur.com/P9E360A.png which it does on firefox but chrome doesn't support the previously used css property and makes it look like this https://i.imgur.com/osz4xXZ.png