### PR TITLE
Hex tag color support

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -18,7 +18,6 @@ import Settings from './settings';
 import ChatWindow from './window';
 
 const regextime = /(\d+(?:\.\d*)?)([a-z]+)?/ig;
-const regexhex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
 const regexsafe = /[\-\[\]\/{}()*+?.\\^$|]/g;
 const nickmessageregex = /(?:(?:^|\s)@?)([a-zA-Z0-9_]{3,20})(?=$|\s|[.?!,])/g;
 const nickregex = /^[a-zA-Z0-9_]{3,20}$/;

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -268,25 +268,6 @@ class Chat {
         return this;
     }
 
-    rebuildHexColorStyles(map) {
-        map.forEach(function (color) {
-            if (color[0] === "#") {
-                color = color.substring(1);
-                var css = ".msg-tagged-" + color + ":before{ background-color: #" + color + "; }",
-                    head = document.head || document.getElementsByTagName('head')[0],
-                    style = document.getElementById("hexColors");
-
-                if (style === null) {
-                    style = document.createElement('style');
-                    style.id = "hexColors"
-                    style.type = 'text/css';
-                    head.appendChild(style);
-                }
-                style.appendChild(document.createTextNode(css));
-            }
-        })
-    }
-
     withGui() {
         this.ui = $('#chat');
         this.css = $('#chat-styles')[0]['sheet'];
@@ -1231,7 +1212,6 @@ class Chat {
     }
 
     createNewClass(color) {
-
         if (color[0] === "#") {
             color = color.substring(1);
             var css = ".msg-tagged-" + color + ":before{ background-color: #" + color + "; }",
@@ -1248,6 +1228,12 @@ class Chat {
                 style.appendChild(document.createTextNode(css));
             }
         }
+    }
+
+    rebuildHexColorStyles(map) {
+        map.forEach((color) => {
+            this.createNewClass(color);
+        })
     }
 
     cmdTAG(parts) {

--- a/assets/chat/js/messages.js
+++ b/assets/chat/js/messages.js
@@ -256,8 +256,8 @@ class ChatUserMessage extends ChatMessage {
             classes.push('msg-highlight');
         if(this.continued && !this.target && !this.targetoutgoing)
             classes.push('msg-continue');
-        if(this.tag)
-            classes.push(`msg-tagged msg-tagged-${this.tag}`);
+        if (this.tag)
+            cleanAndPushClass(classes, this.tag);
         if(this.target)
             classes.push(`msg-whisper`);
         if(this.targetoutgoing)
@@ -279,6 +279,13 @@ class ChatUserMessage extends ChatMessage {
         return this.wrap(buildTime(this) + combined + buildMessageTxt(chat, this), classes, attr);
     }
 
+}
+
+function cleanAndPushClass(classes, tag) {
+if (tag[0] === "#") {
+    tag = tag.substring(1)
+}
+classes.push(`msg-tagged msg-tagged-${tag}`);
 }
 
 function ChatEmoteMessageCount(message){


### PR DESCRIPTION
Added methods for creating classes on tag and rebuilding classes on init.

The hexidecimal classes are generated at runtime and added dynamically to a new <style> section in the head with the id of "hexColors". If a style section with the id exists, it will simply add onto it. Adding several people with the same tag does not create duplicates of the color class. Untagging a user does NOT delete the color class in order to avoid removing other tagged users.

For testing: http://hexpicker.com/#/ff0000