### PR TITLE
add viewer state integration

### DIFF
--- a/assets/chat.js
+++ b/assets/chat.js
@@ -4,12 +4,14 @@ import emotes from './emotes.json';
 
 $.when(
     new Promise(res => $.getJSON(`${API_URI}/api/chat/me`).done(res).fail(() => res(null))),
-    new Promise(res => $.getJSON(`${API_URI}/api/chat/history`).done(res).fail(() => res(null)))
-).then((userAndSettings, history) =>
+    new Promise(res => $.getJSON(`${API_URI}/api/chat/history`).done(res).fail(() => res(null))),
+    new Promise(res => $.getJSON(`${API_URI}/api/chat/viewer-states`).done(res).fail(() => res([])))
+).then((userAndSettings, history, viewerStates) =>
     window.__chat__ = new Chat()
         .withUserAndSettings(userAndSettings)
         .withEmotes(emotes)
         .withGui()
+        .withViewerStates(viewerStates)
         .withHistory(history)
         .withWhispers()
         .connect(WEBSOCKET_URI)

--- a/assets/chat/css/onstream.scss
+++ b/assets/chat/css/onstream.scss
@@ -62,10 +62,12 @@ i[class^="icon-"],
 }
 
 a.user {
+    background-color: transparent;
+    background-position-x: -1000px;
     border: none;
-    background: none;
     color: $text-color;
     box-shadow: none;
+    padding-left: 2px;
     text-shadow:
             -1px -1px 0 rgba(black,0.75),
             1px -1px 1px rgba(black,0.75),

--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -490,16 +490,21 @@ a.user {
     $border-color: lighten( $main-color, 2.5 );
 
     color: $color-label-user;
-    background: $main-color;
-    // background: red;
+    background: transparent;
+    background-repeat: no-repeat;
     padding: 2px;
     padding-top: 3px;
     padding-right: 7px;
+    padding-left: 5px;
     border-radius: 3px;
     border: 1px solid;
     text-shadow: 1px 1px 0px black;
     border-color: $border-color $border-color $main-color $main-color;
     box-shadow: -1px 1px 1px rgba( black, 0.6 );
+}
+.pref-disableviewerstate a.user {
+    background-position-x: -5px;
+    padding-left: 2px;
 }
 a.user:hover {
     color: lighten($color-label-user,20%);
@@ -691,7 +696,7 @@ a.flair12:hover {
     a.user {
         display: inline-block;
         position: relative;
-        background: none;
+        background-position-x: -1000px;
         border: none;
         padding: 0 2px;
         color: #eee;
@@ -729,7 +734,8 @@ a.flair12:hover {
 .msg-whisper a.user:hover {
     text-decoration: none;
     color: $color-accent;
-    background: white;
+    background-color: white;
+    background-position-x: -1000px;
 }
 
 /* Tagging */

--- a/assets/chat/js/messages.js
+++ b/assets/chat/js/messages.js
@@ -271,7 +271,10 @@ class ChatUserMessage extends ChatMessage {
         else if(this.slashme || this.continued)
             ctrl = '';
 
-        const user = buildFeatures(this.user) + ` <a class="user ${this.user.features.join(' ')}">${this.user.username}</a>`;
+        const color = this.user.viewerState.getColor();
+        const viewerStateProps = `title="${this.user.viewerState.getTitle()}" style="background-image: linear-gradient(90deg, ${color}, ${color} 3px, #181818 3px, #181818 1000px);"`;
+
+        const user = buildFeatures(this.user) + ` <a class="user ${this.user.features.join(' ')}" ${viewerStateProps}>${this.user.username}</a>`;
         let combined = ` ${user}<span class="ctrl">${ctrl}</span> `;
         if (this.targetoutgoing){
             combined = ` <span class="ctrl-leading">${ctrl}</span> <a class="user">${this.targetoutgoing}</a> <span class="ctrl">: </span>`;

--- a/assets/chat/js/user.ts
+++ b/assets/chat/js/user.ts
@@ -1,3 +1,5 @@
+import ViewerState from './viewerstate';
+
 interface ICharUserArgs {
     readonly features: readonly string[];
     readonly nick: string;
@@ -7,6 +9,7 @@ class ChatUser {
     public features: readonly string[] = [];
     public nick: string = '';
     public username: string = '';
+    public viewerState: ViewerState = new ViewerState();
 
     constructor(args?: ICharUserArgs) {
         if (args) {

--- a/assets/chat/js/viewerstate.ts
+++ b/assets/chat/js/viewerstate.ts
@@ -1,0 +1,56 @@
+const fnv1a = (input: string) => {
+  let hash = 2166136261;
+  for (let i = 0, len = input.length; i < len; i ++) {
+    hash ^= input.charCodeAt(i);
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+  }
+  return hash >>> 0;
+}
+
+const createRng = (seed: string) => {
+  let n = 0;
+  return () => fnv1a(`${n ++}${seed}`) / 0xffffffff;
+};
+
+const generateColor = (seed: string) => {
+  const rng = createRng(seed);
+  const h = Math.round(rng() * 360);
+  const s = Math.round((rng() * 40) + 20);
+  const l = Math.round((rng() * 40) + 20);
+  return `hsl(${h}, ${s}%, ${l}%)`;
+};
+
+const UNSAFE_CHARS = /[^a-zA-Z _\-\/\(\)]/g;
+const sanitize = (str: string) => str.replace(UNSAFE_CHARS, '');
+
+interface IChannel {
+  readonly channel: string;
+  readonly service: string;
+  readonly path: string;
+}
+
+class ViewerState {
+  public channel: IChannel | null = null;
+
+  constructor(channel: IChannel | null = null) {
+      this.channel = channel;
+  }
+
+  getColor() {
+    if (!this.channel) {
+      return '#292929';
+    }
+    return generateColor(this.channel.channel + this.channel.service);
+  }
+
+  getTitle() {
+    if (!this.channel) {
+      return '';
+    }
+    const {channel, service, path} = this.channel;
+    const title = `${service}/${channel}`;
+    return sanitize(path ? `${path} (${title})` : title);
+  }
+}
+
+export default ViewerState;

--- a/assets/index.html
+++ b/assets/index.html
@@ -90,6 +90,11 @@
                                     <input name="disablespoilers" type="checkbox" /> Disable spoilers
                                 </label>
                             </div>
+                            <div class="form-group checkbox">
+                                <label title="Disable stream viewer indicators">
+                                    <input name="disableviewerstate" type="checkbox" /> Disable stream viewer indicators
+                                </label>
+                            </div>
                             <div class="form-group">
                                 <label for="showremoved">Banned messages</label>
                                 <select class="form-control" id="showremoved" name="showremoved">


### PR DESCRIPTION
Adds an indicator to chat names corresponding to the stream the user is currently viewing...
![preview image](https://i.imgur.com/NpczYQk.png)
The indicator can be disabled in chat settings and broadcasting state can be disabled in strims settings. 
Public state is disabled for all current users but enabled by default.