### PR TITLE
generate emote manifest

### DIFF
--- a/assets/chat/css/emotes.scss
+++ b/assets/chat/css/emotes.scss
@@ -1,0 +1,4 @@
+@import "../../emotes/emoticons";
+@import "weather.scss";
+@import "generify.scss";
+@import "spooky.css";

--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -1,10 +1,6 @@
 @import "../../common";
-@import "../../emotes/emoticons";
 @import "../../icons/icons";
 @import "~roboto-fontface/css/roboto/roboto-fontface.css";
-@import "weather.scss";
-@import "generify.scss";
-@import "spooky.css";
 
 ::selection {
     color: white;


### PR DESCRIPTION
splits the css into two bundles - one for app styles and one for
emote and emote effect styles. adds a webpack plugin to generate
emote-manifest.json containing the names of the emotes and the
path of the new emote css.