### PR TITLE
Stacked emote modifier bug fixes

### DIFF
--- a/assets/chat/css/generify.scss
+++ b/assets/chat/css/generify.scss
@@ -84,7 +84,7 @@
 }
 
 
-.generify-worth .chat-emote:before{
+.generify-worth .chat-emote .worth::before{
     content: "💰";
     text-indent: 0;
     font-size: 18px;
@@ -93,10 +93,10 @@
     top:-25px;
     animation: Shekels-anim 0.5s 8;
 }
-.generify-worth .chat-emote:hover::before{
+.generify-worth .chat-emote .worth:hover::before{
     animation: Shekels-anim 0.5s infinite;
 }
-.generify-worth .chat-emote:after{
+.generify-worth .chat-emote .worth:after{
     content: "💰";
     text-indent: 0;
     font-size: 18px;
@@ -106,7 +106,8 @@
     animation: Shekels-anim 0.5s 8;
     animation-delay: 0.25s;
 }
-.generify-worth .chat-emote:hover::after{
+.generify-worth .chat-emote .worth:hover::after{
+    position: absolute;
     animation: Shekels-anim 0.5s infinite;
     animation-delay: 0.25s;
 }

--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -209,6 +209,14 @@ function genGoldenEmote(emoteName, emoteHeight, emoteWidth) {
     };
 }
 
+function moveModifierToFront(modifierList, modifierName){
+    if(modifierList.includes(modifierName)){
+        modifierList = modifierList.filter(item => item !== modifierName);
+        modifierList.unshift(modifierName);
+    }
+    return modifierList;
+}
+
 class IdentityFormatter {
     format(chat, str, message = null) {
         return str;
@@ -273,6 +281,12 @@ class EmoteFormatter {
                 for(var j = 1; j < input.length; j++)
                 suffixes.push(input[j].replace(/\s/g, ""));
             }
+
+            // the front modifier gets "executed" last
+            suffixes = moveModifierToFront(suffixes, "banned");
+            suffixes = moveModifierToFront(suffixes, "virus");
+            suffixes = moveModifierToFront(suffixes, "dank");
+            suffixes = moveModifierToFront(suffixes, "frozen");
 
             const innerClasses = ["chat-emote", "chat-emote-" + emote];
 

--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -324,13 +324,17 @@ class EmoteFormatter {
                     goldenEmote.goldenModifierInnerEmoteStyle;
             }
             
-            var innerEmote = ' <span ' + goldenModifierInnerEmoteStyle + ' title="' + m + '" class="' + innerClasses.join(' ') + '">' + m + ' </span>';
             var options = [];
             for(var suffix of suffixes){
                 options.push(GENERIFY_OPTIONS[suffix]);
             }
+            options = [...new Set(options)];
+            var shekelSpan = "";
+            if(suffixes.includes('worth')){
+                shekelSpan = "<span class='worth'></span>";
+            }
 
-            options = [...new Set(options)]
+            var innerEmote = ' <span ' + goldenModifierInnerEmoteStyle + ' title="' + m + '" class="' + innerClasses.join(' ') + '">' + m + shekelSpan + ' </span>';
 
             var generifyClasses = [
                 "generify-container",

--- a/assets/chat/js/spoiler.ts
+++ b/assets/chat/js/spoiler.ts
@@ -23,7 +23,7 @@ class ChatSpoiler {
         if(t.hasClass('chat-emote')) {
             t = t.parent();
         }
-        if(t.hasClass('generify-container')) {
+        while(t.hasClass('generify-container')) {
             t = t.parent();
         }
         if(t.hasClass('spoiler visible')) {


### PR DESCRIPTION
- :virus and :banned are not dependent on the position of the suffix anymore and look better with :spin and weather modifiers
- using :hyper and :worth together does not longer result in :hyper being weirdly animated
- you can now click on spoilers containing modified emotes like before

Trayle in chat