### PR TITLE
Fix :hyper and :love not displaying correctly together

### DIFF
--- a/assets/chat/css/generify.scss
+++ b/assets/chat/css/generify.scss
@@ -211,28 +211,28 @@
         animation: generify-love__heart--animation $animation-duration 6;
     }
 
-    &::before {
+    .love::before {
         /* left-outer heart */
         @include heart;
         left: -8px;
         animation-delay: -($animation-duration - $animation-duration*0.25);
     }
 
-    &::after {
+    .love::after {
         /* right-inner heart */
         @include heart;
         right: -2px;
     }
 
     & .chat-emote {
-        &::before {
+        .love::before {
             /* left-inner heart */
             @include heart;
             left: -3px;
             animation-delay: -($animation-duration - ($animation-duration*0.75));
         }
 
-        &::after {
+        .love::after {
             /* right-outer heart */
             @include heart;
             right: -7px;
@@ -241,12 +241,12 @@
     }
 
     &:hover {
-        &::before, &::after {
+        .love::before, .love::after {
             animation-iteration-count: infinite;
         }
 
         & .chat-emote {
-            &::before, &::after {
+            .love::before, .love::after {
                 animation-iteration-count: infinite;
             }
         }

--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -347,8 +347,12 @@ class EmoteFormatter {
             if(suffixes.includes('worth')){
                 shekelSpan = "<span class='worth'></span>";
             }
+            var loveSpan = "";
+            if(suffixes.includes('love')){
+                loveSpan = "<span class='love'></span>";
+            }
 
-            var innerEmote = ' <span ' + goldenModifierInnerEmoteStyle + ' title="' + m + '" class="' + innerClasses.join(' ') + '">' + m + shekelSpan + ' </span>';
+            var innerEmote = ' <span ' + goldenModifierInnerEmoteStyle + ' title="' + m + '" class="' + innerClasses.join(' ') + '">' + m + shekelSpan + loveSpan + ' </span>';
 
             var generifyClasses = [
                 "generify-container",


### PR DESCRIPTION
Currently :hyper does not change the color when used together with :love. The problem was the same as with :worth and :love at first, namely that you can't have multiple ::before and ::after pseudo-elements without css rules overwriting each other

Trayle in chat