### PR TITLE
Waterfall Fix for Initial Load

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,10 @@
 {
-    "presets": ["@babel/preset-env"]
+    "presets": [
+        [
+            "@babel/preset-env",
+            {
+                "useBuiltIns": "entry"
+            }
+        ]
+    ]
 }

--- a/assets/chat.js
+++ b/assets/chat.js
@@ -1,30 +1,18 @@
 import Chat from "./chat/js/chat";
 import emotes from "./emotes.json";
 
-$.when(
-    new Promise(res =>
-        $.getJSON(`${API_URI}/api/chat/me`)
-            .done(res)
-            .fail(() => res(null))
-    ),
-    new Promise(res =>
-        $.getJSON(`${API_URI}/api/chat/history`)
-            .done(res)
-            .fail(() => res(null))
-    ),
-    new Promise(res =>
-        $.getJSON(`${API_URI}/api/chat/viewer-states`)
-            .done(res)
-            .fail(() => res([]))
-    )
-).then(
-    (userAndSettings, history, viewerStates) =>
-        (window.__chat__ = new Chat()
-            .withUserAndSettings(userAndSettings)
-            .withEmotes(emotes)
-            .withGui()
-            .withViewerStates(viewerStates)
-            .withHistory(history)
-            .withWhispers()
-            .connect(WEBSOCKET_URI))
-);
+const init = async v => {
+    const userInfo = async v => await new Promise(res => $.getJSON(`${API_URI}/api/chat/me`).done(res).fail(() => res(null)));
+    const history = async v => await new Promise(res => $.getJSON(`${API_URI}/api/chat/history`).done(res).fail(() => res(null)));
+    const viewerStates = async v => await new Promise(res => $.getJSON(`${API_URI}/api/chat/viewer-states`).done(res).fail(() => res(null)));
+
+    const promiseSync = await Promise.all([userInfo(), history(), viewerStates()]);
+    
+    const chat = new Chat();
+    window.__chat__ = chat; // I do not know why this is needed but included it if an app depends on it
+    await chat.withGui()
+    .then(async() => await Promise.all([chat.withUserAndSettings(promiseSync[0]), chat.withEmotes(emotes), chat.withViewerStates(promiseSync[2]), chat.withHistory(promiseSync[1]), chat.withWhispers()]))
+    .then(() => chat.connect(WEBSOCKET_URI))
+}
+
+init();

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -307,7 +307,7 @@ class Chat {
         );
     }
 
-    withUserAndSettings(data) {
+    async withUserAndSettings(data) {
         return this.withUser(data).withSettings(
             data && data.hasOwnProperty("settings")
                 ? new Map(data.settings)
@@ -359,7 +359,7 @@ class Chat {
         return this;
     }
 
-    withGui() {
+    async withGui() {
         this.ui = $("#chat");
         this.css = $("#chat-styles")[0]["sheet"];
         this.ishidden =
@@ -635,7 +635,7 @@ class Chat {
         return this;
     }
 
-    withEmotes(emotes) {
+    async withEmotes(emotes) {
         this.emoticons = new Set(emotes["default"]);
         for (var s in GENERIFY_OPTIONS) {
             for (var e of this.emoticons) {
@@ -645,7 +645,7 @@ class Chat {
         return this;
     }
 
-    withHistory(history) {
+    async withHistory(history) {
         if (history && history.length > 0) {
             this.backlogloading = true;
             history.forEach(line =>
@@ -658,13 +658,13 @@ class Chat {
         return this;
     }
 
-    withViewerStates(viewerStates) {
-        viewerStates.forEach(state => this.onVIEWERSTATE(state));
+    async withViewerStates(viewerStates) {
+        if(viewerStates) viewerStates.forEach(state => this.onVIEWERSTATE(state));
         return this;
     }
 
-    withWhispers() {
-        if (this.authenticated) {
+    async withWhispers() {
+        // if (this.authenticated) { - This has to be ran because chat loads user info at the same time
             this.whisperStore = new WhisperStore(this.user.nick.toLowerCase());
             this.whisperStore.load().forEach(e => this.whispers.set(e['key'], {
                 id: -1,
@@ -673,11 +673,11 @@ class Chat {
                 open: false
             }));
             this.menus.get('whisper-users').redraw();
-        }
+        // }
         return this;
     }
 
-    connect(uri) {
+    async connect(uri) {
         this.source.connect(uri);
         return this;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -650,6 +650,24 @@
         "regexpu-core": "^4.1.3"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.4.tgz",
+      "integrity": "sha512-8BYcnVqQ5kMD2HXoHInBH7H1b/uP3KdnwCYXOqFnXqguOyuu443WXusbIUbWEfY3Z0Txk0M1uG/8YuAMhNl6zg==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.2.tgz",
@@ -8028,6 +8046,12 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.13.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",
+    "@babel/polyfill": "^7.10.4",
     "@babel/preset-env": "^7.4.2",
     "@types/jquery": "^3.3.29",
     "autoprefixer": "^9.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,6 +151,7 @@ const plugins = [
 
 const entry = {
     'chat': [
+        '@babel/polyfill',
         'core-js/es6',
         'jquery',
         'normalize.css',
@@ -160,6 +161,7 @@ const entry = {
         './assets/chat.js'
     ],
     'chatstreamed': [
+        '@babel/polyfill',
         'core-js/es6',
         'jquery',
         'normalize.css',
@@ -195,6 +197,7 @@ if (process.env.NODE_ENV !== 'production') {
     );
 
     entry['dev-chat'] = [
+        '@babel/polyfill',
         'core-js/es6',
         'jquery',
         'normalize.css',


### PR DESCRIPTION
This fixes the [waterfall](https://i.imgur.com/8LVbbps.png) when chat initially loads. For UX, chat will load twice as fast and the further you are away from the server the more noticeable it is because TTFB now only matters for the last asset loaded.

```if(viewerStates) ``` is then necessary for Dev Chat.

@babel/polyfill is needed to allow async/await when it initializes.

On the right is the waterfall, currently, with assets and API requests being done and waiting for the prior to finish before starting the next. On the left is them all being requested at the same time. Once the websocket loads the user can chat. Since most of the data is quite small, most of the time waiting is the TTFB, by doing all the requests at once the TTFB is only as slow as the last request, effectively.

![dg2xovi 1](https://user-images.githubusercontent.com/50147539/88056378-0fa6b200-cb26-11ea-943c-c556068ae3bb.png)

TLDR ( or because I cannot explain things coherently ) - Loading everything at the same time rather than one by one in a queue.