### PR TITLE
Fix preview sizing for transform-based animated emotes

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -1092,35 +1092,36 @@ a.flair12:hover {
         }
     }
 }
-.autocomplete-emote {
+.autocomplete-emote-container {
+    display: inline-block;
     margin-right: -5px;
     transform: scale(0.6);
 }
-.autocomplete-emote-Abathur {
+.autocomplete-emote-container-Abathur {
     margin-left: -10px;
     margin-right: -10px;
 }
-.autocomplete-emote-AngelThump {
+.autocomplete-emote-container-AngelThump {
     margin-left: -15px;
     margin-right: -15px;
 }
-.autocomplete-emote-DANKMEMES {
+.autocomplete-emote-container-DANKMEMES {
     margin-left: -10px;
     margin-right: -15px;
 }
-.autocomplete-emote-DuckerZ {
+.autocomplete-emote-container-DuckerZ {
     margin-left: -8px;
     margin-right: -8px;
 }
-.autocomplete-emote-GameOfThrows {
+.autocomplete-emote-container-GameOfThrows {
     margin-left: -10px;
     margin-right: -10px;
 }
-.autocomplete-emote-HEADSHOT {
+.autocomplete-emote-container-HEADSHOT {
     margin-left: -10px;
     margin-right: -10px;
 }
-.autocomplete-emote-TRUMPED {
+.autocomplete-emote-container-TRUMPED {
     margin-left: -5px;
     margin-right: -5px;
 }

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -125,7 +125,7 @@ function timeoutHelpers(ac) {
     if (suggestTimeoutId) {
         clearTimeout(suggestTimeoutId);
     }
-    suggestTimeoutId = setTimeout(() => ac.reset(), 15000, ac);
+    suggestTimeoutId = setTimeout(() => ac.reset(), 150000000, ac);
 }
 function updateHelpers(ac) {
     const hasResults = ac.results.length > 0;

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -125,7 +125,7 @@ function timeoutHelpers(ac) {
     if (suggestTimeoutId) {
         clearTimeout(suggestTimeoutId);
     }
-    suggestTimeoutId = setTimeout(() => ac.reset(), 150000000, ac);
+    suggestTimeoutId = setTimeout(() => ac.reset(), 15000, ac);
 }
 function updateHelpers(ac) {
     const hasResults = ac.results.length > 0;

--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -411,13 +411,16 @@ class RawEmoteFormatter {
 // Formats a single emote for display within the autocomplete menu.
 class AutocompleteEmoteFormatter extends RawEmoteFormatter {
     buildElement(chat, emoteName) {
-        const element = super.buildElement(chat, emoteName);
-        element.addClass("autocomplete-emote");
+        const container = new HtmlElement("span");
+        container.addClass("autocomplete-emote-container");
         
         // Some emotes require custom styling. This class does not exist for all emotes.
-        element.addClass(`autocomplete-emote-${emoteName}`);
+        container.addClass(`autocomplete-emote-container-${emoteName}`);
 
-        return element;
+        const emote = super.buildElement(chat, emoteName);
+        container.setContent(emote.toString());
+
+        return container;
     }
 }
 


### PR DESCRIPTION
Emotes that are animated with CSS transforms are not scaled like other emotes when they are rendered within the autocomplete helper. This seems to be happening because the animation transforms are clashing with the scale transform.

I am not 100% sure this fix is correct. Will need to verify in test chat.