### PR TITLE
Fixed some keyboard behaviours on mobile

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -480,7 +480,21 @@ class Chat {
             if (downinoutput) {
                 downinoutput = false;
                 ChatMenu.closeMenus(this);
-                focusIfNothingSelected(this);
+
+                // If on mobile will do a workaround that hides the keyboard because it refocuses the text area if you click on a user name
+                if (navigator.userAgent.indexOf("Mobi") > -1) {
+                    this.input.attr('readonly', 'readonly'); // Force keyboard to hide on input field.
+                    this.input.attr('disabled', 'true'); // Force keyboard to hide on textarea field.
+                    setTimeout(function () {
+                        var input = $("#chat").find("#chat-input-control")
+                        input.blur(); //actually close the keyboard
+                        // Remove readonly attribute after keyboard is hidden.
+                        input.removeAttr('readonly');
+                        input.removeAttr('disabled');
+                    }, 500);
+                } else {
+                    focusIfNothingSelected(this);
+                }
             }
         });
         this.ui.on("click", "#chat-tools-wrap", () => {

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -481,7 +481,7 @@ class Chat {
                 downinoutput = false;
                 ChatMenu.closeMenus(this);
 
-                // If on mobile will do a workaround that hides the keyboard because it refocuses the text area if you click on a user name
+                // If on mobile will hide the keyboard if you click outside the text area
                 if (navigator.userAgent.indexOf("Mobi") > -1) {
                     this.input.attr('readonly', 'readonly'); // Force keyboard to hide on input field.
                     this.input.attr('disabled', 'true'); // Force keyboard to hide on textarea field.

--- a/assets/index.html
+++ b/assets/index.html
@@ -56,7 +56,7 @@
         <div id="chat-input-frame">
             <div id="chat-input-wrap">
                 <div id="chat-input-scaler"></div>
-                <textarea id="chat-input-control" placeholder="Getting things ready ..." autocomplete="off" tabindex="1" autofocus spellcheck></textarea>
+                <textarea id="chat-input-control" placeholder="Getting things ready ..." autocomplete="off" tabindex="1" autofocus spellcheck inputmode="url"></textarea>
             </div>
             <div id="chat-tools-wrap">
                 <a id="chat-emoticon-btn" class="chat-tool-btn" title="Emotes">


### PR DESCRIPTION
Added an input attribute to the text area so that mobile phones properly have a "Submit" button instead of a "Add new line" button(fixes double "enter" to send message).  Added some JS to workaround a keyboard behaviour on mobile when the keyboard is opened and you click on someone's name, causing it to close and then quickly reopen.