### PR TITLE
theoretically adds a basic "pride" suffix

### DIFF
--- a/assets/chat/css/generify.scss
+++ b/assets/chat/css/generify.scss
@@ -603,3 +603,23 @@
         }
     }
 }
+
+.generify-pride {
+  display: inline-block;
+  position: relative;
+}
+.generify-pride::before {
+    position: absolute;
+    background: linear-gradient(to bottom,
+     rgba(255, 0, 0, 0.6) 16%, 
+     rgba(255, 165, 0, 0.6) 16% 33%, 
+     rgba(255, 255, 0, 0.6) 33% 50%, 
+     rgba(0, 255, 0, 0.6) 50% 66%, 
+     rgba(0, 0, 255, 0.6) 66% 83%,
+     rgba(75,0,130, 0.6) 83%
+     );
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 0
+}

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -71,6 +71,7 @@ const GENERIFY_OPTIONS = {
     fast: "fast",
     reverse: "reverse",
     jam: "generify-jam",
+    pride: "generify-pride",
 };
 
 const CUSTOM_AUTOCOMPLETE_ORDER = [


### PR DESCRIPTION
This code theoretically adds a rainbow flag (pride flag) to the sgg interface, following the format of other suffixes in the code. I worked off of my boomer memory to try to find all the places I need to key in a new suffix since the last time I talked to someone about it. I think it's just those two files. In any case, the raw CSS for this works in principle; see https://codepen.io/mafaraxas/pen/yLVXxEr 

Only caveat is (at least in Firefox) whether the flag appears in front of/behind the emote seems to have quirky behavior; the CSS style seems to only make it appear behind and not vanish (regardless of the z-index property) if it's applied to both the `generify-container` span object and the `chat-emote` span object. I suspect that this version will make the flag appear on top of the emote - which is just a choice, and fine, but maybe the flag behind the emote is arguably aesthetically cleaner.

Regardless, my code is shit, but maybe this is enough to get the ball rolling if a cleaner solution is a small step away from this.