### PR TITLE
Fixes for links/popout icon showing through spoiler messages, fix for…

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -359,6 +359,14 @@ label small {
             pointer-events: none;
             color: $color-spoiler-hidden;
         }
+        .embed-externallink{
+            pointer-events: none;
+            visibility: hidden;
+        }
+        .externallink:visited,
+        .embed-internallink:visited {
+            color: $color-spoiler-hidden;
+        }
         .nsfw-link,
         .nsfl-link,
         .loud-link {
@@ -385,6 +393,10 @@ label small {
                 pointer-events: auto;
                 color: $color-link;
             }
+            .embed-externallink{
+                pointer-events:auto;
+                visibility: visible;
+            }
             .externallink:visited {
                 color: $color-link-visited;
             }
@@ -399,6 +411,10 @@ label small {
             }
             .embed-externallink:hover:after {
                 color: $color-link-hover;
+            }
+            .externallink:visited,
+            .embed-internallink:visited {
+                color: $color-link-visited;
             }
             .nsfw-link {
                 border-bottom: 1px dashed $color-underline-nsfw !important;


### PR DESCRIPTION
… small clipping of popout icon through spoilered messages

before:
![image](https://user-images.githubusercontent.com/30268295/133273027-f49c337d-9351-4d4b-83d1-1cb3e2d97df2.png)

after:
![image](https://user-images.githubusercontent.com/30268295/133273247-69a087ee-430c-4340-991f-b5496f46f1d8.png)

![image](https://user-images.githubusercontent.com/30268295/133273291-76dd9f41-9840-4bd9-8cc4-5a636ef17611.png)
