### PR TITLE
Fix digit alignement in unread whisper indicator

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -195,6 +195,7 @@ label small {
     left: 100%;
     position: absolute;
     vertical-align: text-bottom;
+    width: 100%;
 }
 
 #chat-input-wrap {


### PR DESCRIPTION
When my Firefox window gets squeezed really small, and I get many whispers, the unread whisper counter has the digits aligned vertically in a weird way, setting width to 100% fixes it and doesn't seem to break anything on my end.
