### PR TITLE
Added setting for emote animation resetting on combo increments

### DIFF
--- a/assets/chat/css/generify.scss
+++ b/assets/chat/css/generify.scss
@@ -261,6 +261,11 @@
     padding-left: 29px;
 }
 
+.generify-emote-AlienPls.generify-dank {
+    background-size: cover;
+    padding-left: 5px;
+}
+
 .generify-dank > .chat-emote:not(.chat-emote-DANKMEMES) {
     margin-left: 20px;
 }

--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -1490,6 +1490,29 @@ a.flair12:hover {
         display: inline-block;
         max-width: 100%;
     }
+
+    .checkbox.checkbox-indented{
+        margin-left: 40px; margin-top: -5px;
+    }
+    .tree-indent::before{
+        content: "";
+        position: absolute;
+        left: -15px;
+        font-family: $chat-chrome-font;
+        height: 10px;
+        border-left: 1px solid #aaa;
+        border-bottom: 1px solid #aaa;
+        opacity: 0.7;
+    }
+    .tree-indent::after{
+        content: "";
+        position: absolute;
+        border-top: 1px solid #999;
+        left: -15px;
+        width: 5px;
+        top: 10px;
+        opacity: 0.7;
+    }
     .checkbox input {
         appearance: none;
         font: normal normal normal 14px FontAwesome;

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -130,6 +130,7 @@ const settingsdefault = new Map([
     ["formatter-green", true],
     ["formatter-emote", true],
     ["formatter-combo", true],
+    ["reset-animation-combo", true],
     ["holidayemotemodifiers", true],
     ["disablespoilers", false],
     ["viewerstateindicator", 1],

--- a/assets/chat/js/settings.js
+++ b/assets/chat/js/settings.js
@@ -40,6 +40,7 @@ function upgradeSettings(chat, oldversion, newversion) {
         chat.settings.set("notificationsoundfile", arr);
         chat.settings.set("holidayemotemodifiers", arr);
         chat.settings.set("formatter-combo", arr);
+        chat.settings.set("reset-animation-combo", arr);
 
         arr = chat.settings.get("notificationtimeout");
         chat.settings.set("notificationtimeout", arr !== -1);

--- a/assets/dev/dev-chat/settings.json
+++ b/assets/dev/dev-chat/settings.json
@@ -43,5 +43,6 @@
     ["formatter-green", true],
     ["formatter-emote", true],
     ["formatter-combo", true],
+    ["reset-animation-combo", true],
     ["holidayemotemodifiers", true]
 ]

--- a/assets/index.html
+++ b/assets/index.html
@@ -282,6 +282,12 @@
                                 <label title="Display emote combos">
                                     <input name="formatter-combo" type="checkbox" /> Combos
                                 </label>
+                            </div> 
+                            <div class="form-group checkbox checkbox-indented"  >
+                                <span class="tree-indent"></span>
+                                <label title="Reset emote animations on combo">
+                                    <input name="reset-animation-combo" type="checkbox" /> Restart animation on combo
+                                </label>
                             </div>
                             <div class="form-group checkbox">
                                 <label title="Display holiday emote modifiers">


### PR DESCRIPTION
Original behavior (Setting defaults to true):

https://i.imgur.com/gzulYMS.gif

When the setting is disabled:

https://i.imgur.com/96mEhBe.gif

It does also cause this to happen: so be cautious https://i.imgur.com/8vCYT8n.gif

(Notice the animation not restarting after every increment)