### PR TITLE
Rewrite strims.gg stream links to readable "Name - Strim" labels

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -499,6 +499,10 @@ label small {
     .weeb-link {
         border-bottom: 1px dashed $color-underline-weeb !important;
     }
+    .strim-link {
+        font-weight: 600;
+        border-bottom: 1px dashed $color-link !important;
+    }
     .embed-externallink {
         text-decoration: none;
         border-bottom: none;

--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -623,6 +623,7 @@ class UrlFormatter {
         this.discordmp4Regex = /https:\/\/(media|cdn)\.discordapp\.(net|com)\/attachments.*?\.(mp4|webm|mov)/i;
         this.refLinkRegex = /^(https?:\/\/)?(www\.)?(((smile\.)?amazon)|twitter|(open\.)?spotify)\.[a-z]{2,3}/;
         this.twitterRegex = /^(?:https:\/\/)?(?:www\.)?twitter\.com\/([^ ?]+)/i;
+        this.strimLinkRegex = /^https?:\/\/(?:www\.)?strims\.gg\/(angelthump|twitch)\/([a-zA-Z0-9_]+)\/?(?:[?#].*)?$/i;
 
         // e.g. youtube ids include "-" and "_".
         const embedCommonId = '([\\w-]{1,30})';
@@ -735,6 +736,13 @@ class UrlFormatter {
                 url = self.encodeUrl(m[0]);
                 const extra = self.encodeUrl(decodedUrl.substring(m[0].length));
                 const href = scheme + url;
+
+                const strimMatch = decodedUrl.match(self.strimLinkRegex);
+                if (strimMatch) {
+                    const username = strimMatch[2];
+                    const capitalizedUsername = username.charAt(0).toUpperCase() + username.slice(1);
+                    return `<a target="_blank" class="externallink strim-link ${extraclass}" href="${href}" rel="nofollow">${capitalizedUsername} - Strim</a>${extra}`;
+                }
 
                 for (let i = 0; i < this.embedSubstitutions.length; i++) {
                     const sub = this.embedSubstitutions[i];


### PR DESCRIPTION
## What
Raw strims.gg stream links in chat messages (e.g. `https://strims.gg/angelthump/nomdeplume`) currently render as plain, unlabeled full URLs. This adds a `UrlFormatter` rewrite so they display as `<Capitalized-username> - Strim` (e.g. "Nomdeplume - Strim") while the `href` still points at the true URL — same trust model as the existing YouTube-embed labels (hover/right-click-copy shows the real destination).

## Why
This gives readability parity with the existing `embedSubstitutions` handling for external video links (YouTube, Facebook, media.ccc.de), which already get a friendly internal label instead of a raw URL. Our own strims.gg stream links had no such treatment and stood out as unreadable full URLs in chat.

## Scope decision
Only `/angelthump/<username>` and `/twitch/<username>` are matched — these are the two routes where the final path segment is a real channel/username. `/youtube/<id>`, `/twitch-vod/<id>`, `/facebook/<id>`, and `/advanced/...` are intentionally excluded because their path segment is an opaque video/VOD ID, not a username — relabeling those as "Name - Strim" would be misleading (e.g. showing "2Kltvxckm-W - Strim" instead of a real name).