### PR TITLE
Allow external images and media in CSP

### DIFF
--- a/assets/discordmedia.js
+++ b/assets/discordmedia.js
@@ -1,9 +1,33 @@
-const source = decodeURIComponent(location.search).replace(/^\?v=/, '');
+const ALLOWED_HOSTS = ['cdn.discordapp.com', 'media.discordapp.net'];
+const ALLOWED_EXTENSIONS = /\.(mp4|webm|mov)$/i;
 
-if (/https:\/\/(media|cdn)\.discordapp\.(net|com)\/attachments.*?\.(mp4|webm|mov)/i.test(source)) {
-  const video = document.createElement('video');
-  video.src = source;
-  video.controls = true;
-  video.autoplay = true;
-  document.body.appendChild(video);
+// Parse the URL rather than pattern matching the raw string: a test() anywhere
+// in the input accepts https://evil.com/#https://cdn.discordapp.com/a.mp4 and
+// then loads evil.com, since it is the whole string that reaches video.src.
+function parseAttachmentUrl (raw) {
+    let url;
+    try {
+        url = new URL(raw);
+    } catch (err) {
+        return null;
+    }
+    if (url.protocol !== 'https:' || !ALLOWED_HOSTS.includes(url.hostname)) {
+        return null;
+    }
+    // Match against pathname so Discord's signed ?ex=&is=&hm= params are ignored.
+    if (!url.pathname.startsWith('/attachments/') || !ALLOWED_EXTENSIONS.test(url.pathname)) {
+        return null;
+    }
+    return url;
+}
+
+const source = decodeURIComponent(location.search).replace(/^\?v=/, '');
+const url = parseAttachmentUrl(source);
+
+if (url) {
+    const video = document.createElement('video');
+    video.src = url.href;
+    video.controls = true;
+    video.autoplay = true;
+    document.body.appendChild(video);
 }

--- a/config/nginx.txt
+++ b/config/nginx.txt
@@ -9,7 +9,7 @@ server {
     add_header X-Content-Type-Options nosniff;
     add_header Referrer-Policy "same-origin";
     add_header Feature-Policy "geolocation 'none'; microphone 'none'; camera 'none'";
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self' wss:; img-src 'self' data:; frame-ancestors https://strims.gg; base-uri 'self'; form-action 'self'";
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self' wss:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; frame-ancestors https://strims.gg; base-uri 'self'; form-action 'self'";
 
     # TODO
     add_header Cache-Control no-cache;


### PR DESCRIPTION
## What changed

Allow the chat to load images and videos from external HTTPS links.

Makes it possible to embed images and MP4 videos directly instead of converting them to data URLs. Everything else in the security policy stays the same.