### PR TITLE
Match bare strims.gg/<name> links and make https optional

### DIFF
--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -623,7 +623,7 @@ class UrlFormatter {
         this.discordmp4Regex = /https:\/\/(media|cdn)\.discordapp\.(net|com)\/attachments.*?\.(mp4|webm|mov)/i;
         this.refLinkRegex = /^(https?:\/\/)?(www\.)?(((smile\.)?amazon)|twitter|(open\.)?spotify)\.[a-z]{2,3}/;
         this.twitterRegex = /^(?:https:\/\/)?(?:www\.)?twitter\.com\/([^ ?]+)/i;
-        this.strimLinkRegex = /^https?:\/\/(?:www\.)?strims\.gg\/(angelthump|twitch)\/([a-zA-Z0-9_]+)\/?(?:[?#].*)?$/i;
+        this.strimLinkRegex = /^(?:https?:\/\/)?(?:www\.)?strims\.gg\/(?:(?:angelthump|twitch)\/)?([a-zA-Z0-9_]+)\/?(?:[?#].*)?$/i;
 
         // e.g. youtube ids include "-" and "_".
         const embedCommonId = '([\\w-]{1,30})';
@@ -739,7 +739,7 @@ class UrlFormatter {
 
                 const strimMatch = decodedUrl.match(self.strimLinkRegex);
                 if (strimMatch) {
-                    const username = strimMatch[2];
+                    const username = strimMatch[1];
                     const capitalizedUsername = username.charAt(0).toUpperCase() + username.slice(1);
                     return `<a target="_blank" class="externallink strim-link ${extraclass}" href="${href}" rel="nofollow">${capitalizedUsername} - Strim</a>${extra}`;
                 }


### PR DESCRIPTION
strimLinkRegex previously required a full https:// scheme and an angelthump/twitch path prefix, so plain-text or scheme-less strims.gg/<name> links weren't relabeled.